### PR TITLE
add torrentCount for faster browsing

### DIFF
--- a/app/models/Category.js
+++ b/app/models/Category.js
@@ -5,7 +5,8 @@ var categorySchema = mongoose.Schema({
     slug: String,
     aliases: [
         String
-    ]
+    ],
+    torrentCount: Number
 });
 
 function slugify(text) {

--- a/app/models/Torrent.js
+++ b/app/models/Torrent.js
@@ -1,4 +1,5 @@
-var mongoose = require('mongoose');
+var mongoose = require('mongoose'),
+    Category = require('./Category.js');
 
 var torrentSchema = mongoose.Schema({
     title: {
@@ -29,6 +30,25 @@ var torrentSchema = mongoose.Schema({
     }
 });
 
-torrentSchema.index({ title: 'text' });
+torrentSchema.index({
+    title: 'text'
+});
+
+torrentSchema.pre('save', function (next) {
+    if (this.isNew) {
+        Category.update({
+            _id: this.category
+        },{
+            $inc: { torrentCount: 1 }
+        }).exec(function(err, updatedDoc){
+            if(err){ console.log(err); }
+            if(updatedDoc){
+                next();
+            } else {
+                console.log('We couldn\'t update the torrent count');
+            }
+        });
+    }
+});
 
 module.exports = mongoose.model('Torrent', torrentSchema);

--- a/app/routes/core.js
+++ b/app/routes/core.js
@@ -32,16 +32,21 @@ module.exports = (function() {
     app.get('/browse', function(req, res){
         Category.find({}).sort({
             'title': 1
-        }).lean().exec(function(err, categories){
+        }).exec(function(err, categories){
             if(err) { console.log(err); }
             async.each(categories, function(category, callback) {
-                Torrent.count({
-                    category: category._id
-                }).exec(function(err, torrentCount){
-                    if(err) { console.log(err); }
-                    category.torrentCount = torrentCount;
+                if(category.torrentCount < 0){
+                    Torrent.count({
+                        category: category._id
+                    }).exec(function(err, torrentCount){
+                        if(err) { console.log(err); }
+                        category.torrentCount = torrentCount;
+                        category.save();
+                        callback(null);
+                    });
+                } else {
                     callback(null);
-                });
+                }
             }, function(err){
                 if(err) { console.log(err); }
                 res.render('browse', {

--- a/imports/.gitignore
+++ b/imports/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Imports now use `imports/kat.txt` instead of `import.txt`.

I'll be adding in support for other sites soon as well as auto downloading hourly imports from providers.
