### PR TITLE
add sort by textScore before sorting

### DIFF
--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -178,7 +178,11 @@ module.exports = (function() {
         var limit = req.query.limit || nconf.get('web:torrentsPerPage'),
             sorting = (req.query.sort || nconf.get('web:defaultSearchSorting')).toLowerCase(),
             order = (req.query.order || nconf.get('web:defaultSearchOrder')).toLowerCase(),
-            sort = {},
+            sort = {
+                score: {
+                    $meta: 'textScore'
+                }
+            },
             search = {};
         async.waterfall([
             function(callback) {


### PR DESCRIPTION
This should mean that results sent back from the api are first sorted by textscore and then by the sorting param.
