### PR TITLE
Add snapcraft.yaml and wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,8 @@ import.txt
 # Log files
 *.log
 
+# Snapcraft
+snap/*/
+snap/*.snap
+
 .nyc_output

--- a/snap/astro-imports.wrapper
+++ b/snap/astro-imports.wrapper
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+# This probably won't be needed once confinement is enabled but should be left in anyway since not all OS's support snaps confinement yet e.g ArchLinux and Fedora
+DIR="$(dirname $0)"
+
+cd "$DIR/../lib/node_modules/astro" || exit 1
+
+"$DIR/"yarn start:background:imports

--- a/snap/astro-imports.wrapper
+++ b/snap/astro-imports.wrapper
@@ -5,6 +5,8 @@ set -e
 # This probably won't be needed once confinement is enabled but should be left in anyway since not all OS's support snaps confinement yet e.g ArchLinux and Fedora
 DIR="$(dirname $0)"
 
+export PATH="$DIR:$PATH"
+
 cd "$DIR/../lib/node_modules/astro" || exit 1
 
 "$DIR/"yarn start:background:imports

--- a/snap/astro-imports.wrapper
+++ b/snap/astro-imports.wrapper
@@ -9,4 +9,4 @@ export PATH="$DIR:$PATH"
 
 cd "$DIR/../lib/node_modules/astro" || exit 1
 
-"$DIR/"yarn start:background:imports
+"$DIR/"npm run-script start:background:imports

--- a/snap/astro.wrapper
+++ b/snap/astro.wrapper
@@ -5,6 +5,8 @@ set -e
 # This probably won't be needed once confinement is enabled but should be left in anyway since not all OS's support snaps confinement yet e.g ArchLinux and Fedora
 DIR="$(dirname $0)"
 
+export PATH="$DIR:$PATH"
+
 cd "$DIR/../lib/node_modules/astro" || exit 1
 
 "$DIR/"yarn start

--- a/snap/astro.wrapper
+++ b/snap/astro.wrapper
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+# This probably won't be needed once confinement is enabled but should be left in anyway since not all OS's support snaps confinement yet e.g ArchLinux and Fedora
+DIR="$(dirname $0)"
+
+cd "$DIR/../lib/node_modules/astro" || exit 1
+
+"$DIR/"yarn start

--- a/snap/astro.wrapper
+++ b/snap/astro.wrapper
@@ -9,4 +9,4 @@ export PATH="$DIR:$PATH"
 
 cd "$DIR/../lib/node_modules/astro" || exit 1
 
-"$DIR/"yarn start
+"$DIR/"npm start

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,3 +30,4 @@ parts:
     plugin: copy
     files:
         astro.wrapper: bin/astro
+        astro-imports.wrapper: bin/astro-imports

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,22 +10,27 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: devmode # use 'strict' once you have the right plugs and slots
 
+apps:
+  astro-web:
+    command: bin/astro
+    daemon: simple
+  astro-imports:
+    command: bin/astro-imports
+    daemon: simple
+
 parts:
   guessit:
     plugin: python
     python-packages:
       - guessit
-  yarn:
-    plugin: nodejs
-    node-packages:
-      - yarn
   astro:
     source: ..
     plugin: nodejs
     prepare: |
       sed -i 's/logs\/error.log/\/dev\/stdout/g' app/config/index.js
       mkdir -p $SNAPCRAFT_PART_INSTALL/lib/node_modules/astro
-      cp -R . $SNAPCRAFT_PART_INSTALL/lib/node_modules/astro/
+      rsync -av --exclude=.git ./ $SNAPCRAFT_PART_INSTALL/lib/node_modules/astro/
+    build-packages: [rsync]
   astro-dev-dependencies:
     plugin: nodejs
     node-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,10 @@ parts:
   astro:
     source: ..
     plugin: nodejs
+    prepare: |
+      sed -i 's/logs\/error.log/\/dev\/stdout/g' app/config/index.js
+      mkdir -p $SNAPCRAFT_PART_INSTALL/lib/node_modules/astro
+      cp -R . $SNAPCRAFT_PART_INSTALL/lib/node_modules/astro/
   astro-dev-dependencies:
     plugin: nodejs
     node-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: astro # you probably want to 'snapcraft register <name>'
+version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  guessit:
+    plugin: python
+    python-packages:
+      - guessit
+  yarn:
+    plugin: nodejs
+    node-packages:
+      - yarn
+  astro:
+    source: ..
+    plugin: nodejs
+  astro-dev-dependencies:
+    plugin: nodejs
+    node-packages:
+      - '@ava/babel-preset-transform-test-files'
+  wrapper:
+    plugin: copy
+    files:
+        astro.wrapper: bin/astro


### PR DESCRIPTION
### Fix or Enhancement?

This pull request is a WIP to package astro up as a [snap](https://snapcraft.io/) application. This will enable easy installation on Linux devices (desktops and / or servers) via a simple `snap install astro` (note: we'll have to register the astro name in the snap store first). We can also automatically build the snap package via the snapcraft [build service](https://build.snapcraft.io/).

To build the snap:

```sh
cd /path/to/astro
docker run -it --rm -v "$PWD:$PWD" -w $PWD/snap snapcore/snapcraft bash
apt update
snapcraft
```

This will produce a .snap file that can be installed on a snap enabled Linux device as follows:

`sudo snap install --devmode ./astro_0.1_amd64.snap`

To Do:

- [x] Register "astro" on the snap store
- [x] Run astro as a background daemon
- [ ] Enable and test confinement (sandboxing)
- [ ] Fix logging - Because snaps are read-only filesystems astro currently fails on startup as follows:

```sh
❯ /snap/astro/current/bin/astro
yarn start v0.24.5
$ cross-env NODE_ENV=production babel-node index.js | bunyan 
[2017-06-06T18:08:03.914Z]  INFO: Astro/7719 on harris: Astro is running on port 3000 (version=1.1.0)
[2017-06-06T18:08:03.915Z]  WARN: Astro/7719 on harris: Uncaught Exception. Shutting down. (version=1.1.0)
[2017-06-06T18:08:03.915Z]  WARN: Astro/7719 on harris: EROFS: read-only file system, open 'logs/error.log' (version=1.1.0)
Done in 0.87s.
```

I'll need to read-up on the correct way to log in a snap application to fix this (although logging to stdout seems to be working fine).

- [ ] All tests passed

### Environment
- OS: Linux
- Node version: 6.10.2
